### PR TITLE
Add Swagger documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,11 +6,15 @@ const clientRoutes = require('./routes/clientRoutes');
 const saleRoutes = require('./routes/saleRoutes');
 const osRoutes = require('./routes/osRoutes');
 const userRoutes = require('./routes/userRoutes');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./swagger');
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 app.use('/uploads', express.static('uploads'));
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/api', loginRoutes);
 app.use('/api/products', productRoutes);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dotenv": "^16.3.1",
     "jsonwebtoken": "^9.0.1",
     "multer": "^1.4.5-lts.1",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "swagger-ui-express": "^4.7.1",
+    "swagger-jsdoc": "^6.2.8"
   }
 }

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -3,6 +3,35 @@ const router = express.Router();
 const productController = require('../controllers/productController');
 const auth = require('../middleware/authMiddleware');
 
+/**
+ * @swagger
+ * /api/products:
+ *   get:
+ *     summary: Retrieve all products
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of products
+ *   post:
+ *     summary: Create a product
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               price:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Created product
+ */
 router.get('/', auth, productController.getAll);
 router.post('/', auth, productController.create);
 

--- a/swagger.js
+++ b/swagger.js
@@ -1,0 +1,23 @@
+const swaggerJsDoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Backend API',
+      version: '1.0.0',
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+  },
+  apis: ['./routes/*.js'],
+};
+
+module.exports = swaggerJsDoc(options);


### PR DESCRIPTION
## Summary
- add `swagger-ui-express` and `swagger-jsdoc` dependencies
- expose `/api-docs` route in `app.js`
- generate swagger spec via new `swagger.js`
- document product routes with Swagger annotations

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68403fdf75788333aea1202399f59c92