### PR TITLE
Update swagger-ui-express version and add Node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "backend",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
   "main": "server.js",
   "scripts": {
     "start": "node server.js"
@@ -12,7 +15,7 @@
     "jsonwebtoken": "^9.0.1",
     "multer": "^1.4.5-lts.1",
     "cors": "^2.8.5",
-    "swagger-ui-express": "^4.7.1",
+    "swagger-ui-express": "^5.0.0",
     "swagger-jsdoc": "^6.2.8"
   }
 }


### PR DESCRIPTION
## Summary
- bump swagger-ui-express from 4.7.1 to 5.0.0
- require Node >=18 for the project

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68404118383c8333ab0dae573a6003ee