### PR TITLE
Add Swagger docs for route endpoints

### DIFF
--- a/routes/clientRoutes.js
+++ b/routes/clientRoutes.js
@@ -3,6 +3,21 @@ const router = express.Router();
 const clientController = require('../controllers/clientController');
 const auth = require('../middleware/authMiddleware');
 
+/**
+ * @swagger
+ * /api/clients:
+ *   get:
+ *     summary: Retrieve all clients
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of clients
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
 router.get('/', auth, clientController.getAll);
 
 module.exports = router;

--- a/routes/loginRoutes.js
+++ b/routes/loginRoutes.js
@@ -2,6 +2,30 @@ const express = require('express');
 const router = express.Router();
 const authController = require('../controllers/authController');
 
+/**
+ * @swagger
+ * /api/login:
+ *   post:
+ *     summary: Authenticate user and return a JWT token
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Authentication successful
+ *       401:
+ *         description: Invalid credentials
+ *       500:
+ *         description: Server error
+ */
 router.post('/login', authController.login);
 
 module.exports = router;

--- a/routes/osRoutes.js
+++ b/routes/osRoutes.js
@@ -3,6 +3,21 @@ const router = express.Router();
 const osController = require('../controllers/osController');
 const auth = require('../middleware/authMiddleware');
 
+/**
+ * @swagger
+ * /api/os:
+ *   get:
+ *     summary: Retrieve all service orders
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of service orders
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
 router.get('/', auth, osController.getAll);
 
 module.exports = router;

--- a/routes/saleRoutes.js
+++ b/routes/saleRoutes.js
@@ -3,6 +3,21 @@ const router = express.Router();
 const saleController = require('../controllers/saleController');
 const auth = require('../middleware/authMiddleware');
 
+/**
+ * @swagger
+ * /api/sales:
+ *   get:
+ *     summary: Retrieve all sales
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of sales
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
 router.get('/', auth, saleController.getAll);
 
 module.exports = router;

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -4,6 +4,23 @@ const userController = require('../controllers/userController');
 const auth = require('../middleware/authMiddleware');
 const permissoes = require('../middleware/permissoesMiddleware');
 
+/**
+ * @swagger
+ * /api/users:
+ *   get:
+ *     summary: Retrieve all users (admin only)
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of users
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Forbidden
+ *       500:
+ *         description: Server error
+ */
 router.get('/', auth, permissoes('admin'), userController.getAll);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- document login routes
- document client routes
- document service order routes
- document sales routes
- document user routes

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684043361c788333a0bbd2973b8a9211