### PR TITLE
Add create user endpoint

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -8,3 +8,16 @@ exports.getAll = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.create = async (req, res) => {
+  const { username, password, role } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO users (username, password, role) VALUES ($1, $2, $3) RETURNING id',
+      [username, password, role]
+    );
+    res.json({ id: rows[0].id, username, role });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -23,4 +23,36 @@ const permissoes = require('../middleware/permissoesMiddleware');
  */
 router.get('/', auth, permissoes('admin'), userController.getAll);
 
+/**
+ * @swagger
+ * /api/users:
+ *   post:
+ *     summary: Create a user (admin only)
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *               role:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Created user
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Forbidden
+ *       500:
+ *         description: Server error
+ */
+router.post('/', auth, permissoes('admin'), userController.create);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- implement controller logic for adding a user
- document and expose `POST /api/users` endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./app')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684044eaea408333b1b97265e21a7aed