### PR TITLE
Add role list for user creation

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -43,6 +43,10 @@ router.get('/', auth, permissoes('admin'), userController.getAll);
  *                 type: string
  *               role:
  *                 type: string
+ *                 enum:
+ *                   - admin
+ *                   - estoquista
+ *                   - vendedor
  *     responses:
  *       200:
  *         description: Created user


### PR DESCRIPTION
## Summary
- show list of valid roles in the Swagger docs for creating a user

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68404d8f8d448333997d85eecdd17d68