### PR TITLE
Add Swagger tags for route prefixes

### DIFF
--- a/routes/clientRoutes.js
+++ b/routes/clientRoutes.js
@@ -5,8 +5,17 @@ const auth = require('../middleware/authMiddleware');
 
 /**
  * @swagger
+ * tags:
+ *   name: Clients
+ *   description: Client management endpoints
+ */
+
+/**
+ * @swagger
  * /api/clients:
  *   get:
+ *     tags:
+ *       - Clients
  *     summary: Retrieve all clients
  *     security:
  *       - bearerAuth: []

--- a/routes/loginRoutes.js
+++ b/routes/loginRoutes.js
@@ -4,8 +4,17 @@ const authController = require('../controllers/authController');
 
 /**
  * @swagger
+ * tags:
+ *   name: Login
+ *   description: Authentication endpoints
+ */
+
+/**
+ * @swagger
  * /api/login:
  *   post:
+ *     tags:
+ *       - Login
  *     summary: Authenticate user and return a JWT token
  *     requestBody:
  *       required: true

--- a/routes/osRoutes.js
+++ b/routes/osRoutes.js
@@ -5,8 +5,17 @@ const auth = require('../middleware/authMiddleware');
 
 /**
  * @swagger
+ * tags:
+ *   name: OS
+ *   description: Service order endpoints
+ */
+
+/**
+ * @swagger
  * /api/os:
  *   get:
+ *     tags:
+ *       - OS
  *     summary: Retrieve all service orders
  *     security:
  *       - bearerAuth: []

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -5,8 +5,17 @@ const auth = require('../middleware/authMiddleware');
 
 /**
  * @swagger
+ * tags:
+ *   name: Products
+ *   description: Product management endpoints
+ */
+
+/**
+ * @swagger
  * /api/products:
  *   get:
+ *     tags:
+ *       - Products
  *     summary: Retrieve all products
  *     security:
  *       - bearerAuth: []
@@ -14,6 +23,8 @@ const auth = require('../middleware/authMiddleware');
  *       200:
  *         description: List of products
  *   post:
+ *     tags:
+ *       - Products
  *     summary: Create a product
  *     security:
  *       - bearerAuth: []

--- a/routes/saleRoutes.js
+++ b/routes/saleRoutes.js
@@ -5,8 +5,17 @@ const auth = require('../middleware/authMiddleware');
 
 /**
  * @swagger
+ * tags:
+ *   name: Sales
+ *   description: Sales management endpoints
+ */
+
+/**
+ * @swagger
  * /api/sales:
  *   get:
+ *     tags:
+ *       - Sales
  *     summary: Retrieve all sales
  *     security:
  *       - bearerAuth: []

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -6,8 +6,17 @@ const permissoes = require('../middleware/permissoesMiddleware');
 
 /**
  * @swagger
+ * tags:
+ *   name: Users
+ *   description: User management endpoints
+ */
+
+/**
+ * @swagger
  * /api/users:
  *   get:
+ *     tags:
+ *       - Users
  *     summary: Retrieve all users (admin only)
  *     security:
  *       - bearerAuth: []
@@ -27,6 +36,8 @@ router.get('/', auth, permissoes('admin'), userController.getAll);
  * @swagger
  * /api/users:
  *   post:
+ *     tags:
+ *       - Users
  *     summary: Create a user
  *     requestBody:
  *       required: true

--- a/swagger.js
+++ b/swagger.js
@@ -7,6 +7,14 @@ const options = {
       title: 'Backend API',
       version: '1.0.0',
     },
+    tags: [
+      { name: 'Login', description: 'Endpoints for user authentication' },
+      { name: 'Products', description: 'Product management endpoints' },
+      { name: 'Clients', description: 'Client management endpoints' },
+      { name: 'Sales', description: 'Sales management endpoints' },
+      { name: 'OS', description: 'Service order endpoints' },
+      { name: 'Users', description: 'User management endpoints' },
+    ],
     components: {
       securitySchemes: {
         bearerAuth: {


### PR DESCRIPTION
## Summary
- group endpoints in Swagger docs by adding tags for login, products, clients, sales, service orders, and users
- define tag descriptions in swagger configuration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684050bd8a6c8333988ec3cd00b16d3f