### PR TITLE
Add simple SQL migration utility

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const pool = require('./config/db');
+
+async function run() {
+  const client = await pool.connect();
+  try {
+    await client.query(`CREATE TABLE IF NOT EXISTS migrations (
+      id SERIAL PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      run_on TIMESTAMP NOT NULL DEFAULT NOW()
+    )`);
+
+    const { rows } = await client.query('SELECT name FROM migrations');
+    const applied = new Set(rows.map(r => r.name));
+
+    const dir = path.join(__dirname, 'migrations');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+
+    for (const file of files) {
+      if (applied.has(file)) continue;
+      const sql = fs.readFileSync(path.join(dir, file), 'utf8');
+      console.log(`Running ${file}...`);
+      await client.query(sql);
+      await client.query('INSERT INTO migrations(name) VALUES($1)', [file]);
+    }
+
+    console.log('Migrations complete.');
+  } catch (err) {
+    console.error('Migration failed', err);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+run();

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) UNIQUE NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  role VARCHAR(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS clients (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT
+);
+
+CREATE TABLE IF NOT EXISTS products (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  price NUMERIC(10, 2) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sales (
+  id SERIAL PRIMARY KEY,
+  product_id INTEGER REFERENCES products(id),
+  quantity INTEGER NOT NULL,
+  total NUMERIC(10, 2) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS service_orders (
+  id SERIAL PRIMARY KEY,
+  description TEXT NOT NULL
+);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   },
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "migrate": "node migrate.js"
   },
   "dependencies": {
     "express": "^4.18.2",


### PR DESCRIPTION
## Summary
- implement `migrate.js` to run SQL migrations
- track migration files in a new `migrations` directory
- provide an example migration that sets up base tables
- expose `npm run migrate` script

## Testing
- `npm run migrate` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6840534c9bd08333ada4a24e1352fb0d