### PR TITLE
Add service order creation route and model

### DIFF
--- a/controllers/osController.js
+++ b/controllers/osController.js
@@ -8,3 +8,16 @@ exports.getAll = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.create = async (req, res) => {
+  const { description } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO service_orders (description) VALUES ($1) RETURNING id',
+      [description]
+    );
+    res.json({ id: rows[0].id, description });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   User: require('./userModel'),
   Product: require('./productModel'),
-  Client: require('./clientModel')
+  Client: require('./clientModel'),
+  ServiceOrder: require('./osModel')
 };

--- a/models/osModel.js
+++ b/models/osModel.js
@@ -1,0 +1,14 @@
+const pool = require('../config/db');
+
+exports.getAll = async () => {
+  const { rows } = await pool.query('SELECT * FROM service_orders');
+  return rows;
+};
+
+exports.create = async (description) => {
+  const { rows } = await pool.query(
+    'INSERT INTO service_orders (description) VALUES ($1) RETURNING id',
+    [description]
+  );
+  return rows[0];
+};

--- a/routes/osRoutes.js
+++ b/routes/osRoutes.js
@@ -29,4 +29,28 @@ const auth = require('../middleware/authMiddleware');
  */
 router.get('/', auth, osController.getAll);
 
+/**
+ * @swagger
+ * /api/os:
+ *   post:
+ *     tags:
+ *       - OS
+ *     summary: Create a service order
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               description:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Created service order
+ */
+router.post('/', auth, osController.create);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- create model for service orders
- export ServiceOrder model from index
- add creation logic in service order controller
- document and expose POST /api/os route

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68407c88c89c8333a5c9b704092c2b18