### PR TITLE
Add dashboard statistics endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const clientRoutes = require('./routes/clientRoutes');
 const saleRoutes = require('./routes/saleRoutes');
 const osRoutes = require('./routes/osRoutes');
 const userRoutes = require('./routes/userRoutes');
+const dashboardRoutes = require('./routes/dashboardRoutes');
 const swaggerUi = require('swagger-ui-express');
 const swaggerSpec = require('./swagger');
 
@@ -22,5 +23,6 @@ app.use('/api/clients', clientRoutes);
 app.use('/api/sales', saleRoutes);
 app.use('/api/os', osRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 module.exports = app;

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -1,0 +1,28 @@
+const pool = require('../config/db');
+
+exports.getStats = async (_req, res) => {
+  try {
+    const salesResult = await pool.query(
+      'SELECT COALESCE(SUM(total), 0) AS total FROM sales WHERE DATE(created_at) = CURRENT_DATE'
+    );
+    const stockResult = await pool.query(
+      'SELECT COUNT(*) AS total FROM stock_entries WHERE DATE(date) = CURRENT_DATE'
+    );
+    const workResult = await pool.query(
+      "SELECT COUNT(*) AS total FROM work_orders WHERE status = 'in_progress'"
+    );
+    const cashResult = await pool.query(
+      'SELECT balance FROM cashbox ORDER BY id DESC LIMIT 1'
+    );
+
+    res.json({
+      dailySales: salesResult.rows[0]?.total || 0,
+      stockEntriesToday: parseInt(stockResult.rows[0]?.total, 10) || 0,
+      workOrdersInProgress: parseInt(workResult.rows[0]?.total, 10) || 0,
+      currentCash: cashResult.rows[0]?.balance || 0,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/migrations/002_dashboard_tables.sql
+++ b/migrations/002_dashboard_tables.sql
@@ -1,0 +1,23 @@
+-- Create additional tables used by dashboard statistics
+
+-- add created_at column to sales if not exists
+ALTER TABLE sales
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+-- table for stock entries
+CREATE TABLE IF NOT EXISTS stock_entries (
+  id SERIAL PRIMARY KEY,
+  date DATE NOT NULL
+);
+
+-- table for work orders
+CREATE TABLE IF NOT EXISTS work_orders (
+  id SERIAL PRIMARY KEY,
+  status TEXT NOT NULL
+);
+
+-- table for cashbox balance records
+CREATE TABLE IF NOT EXISTS cashbox (
+  id SERIAL PRIMARY KEY,
+  balance NUMERIC(10,2) NOT NULL
+);

--- a/routes/dashboardRoutes.js
+++ b/routes/dashboardRoutes.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const router = express.Router();
+const dashboardController = require('../controllers/dashboardController');
+const auth = require('../middleware/authMiddleware');
+
+/**
+ * @swagger
+ * tags:
+ *   name: Dashboard
+ *   description: Dashboard statistics endpoints
+ */
+
+/**
+ * @swagger
+ * /api/dashboard/stats:
+ *   get:
+ *     tags:
+ *       - Dashboard
+ *     summary: Retrieve dashboard statistics
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Dashboard stats
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Server error
+ */
+router.get('/stats', auth, dashboardController.getStats);
+
+module.exports = router;

--- a/swagger.js
+++ b/swagger.js
@@ -14,6 +14,7 @@ const options = {
       { name: 'Sales', description: 'Sales management endpoints' },
       { name: 'OS', description: 'Service order endpoints' },
       { name: 'Users', description: 'User management endpoints' },
+      { name: 'Dashboard', description: 'Dashboard statistics endpoints' },
     ],
     components: {
       securitySchemes: {


### PR DESCRIPTION
## Summary
- provide a controller and route for dashboard statistics
- wire dashboard routes into the app and swagger docs
- create migration for missing dashboard tables and add `created_at` to sales

## Testing
- `npm run migrate` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6840db37d55c8333af48ae8a480d1f3e