### PR TITLE
Add sales creation endpoint

### DIFF
--- a/controllers/saleController.js
+++ b/controllers/saleController.js
@@ -8,3 +8,16 @@ exports.getAll = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.create = async (req, res) => {
+  const { product_id, quantity, total } = req.body;
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO sales (product_id, quantity, total) VALUES ($1, $2, $3) RETURNING id',
+      [product_id, quantity, total]
+    );
+    res.json({ id: rows[0].id, product_id, quantity, total });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/routes/saleRoutes.js
+++ b/routes/saleRoutes.js
@@ -29,4 +29,33 @@ const auth = require('../middleware/authMiddleware');
  */
 router.get('/', auth, saleController.getAll);
 
+/**
+ * @swagger
+ * /api/sales:
+ *   post:
+ *     tags:
+ *       - Sales
+ *     summary: Create a sale
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               product_id:
+ *                 type: integer
+ *               quantity:
+ *                 type: integer
+ *               total:
+ *                 type: number
+ *                 format: float
+ *     responses:
+ *       200:
+ *         description: Created sale
+ */
+router.post('/', auth, saleController.create);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add controller logic for creating sales
- document and expose POST /api/sales route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3c0bd448333a7c0c51a47feb76d