### PR TITLE
Add refresh token on login

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -11,7 +11,8 @@ exports.login = async (req, res) => {
     }
     const user = rows[0];
     const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
-    res.json({ token });
+    const refreshToken = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token, refreshToken });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/routes/loginRoutes.js
+++ b/routes/loginRoutes.js
@@ -15,7 +15,7 @@ const authController = require('../controllers/authController');
  *   post:
  *     tags:
  *       - Login
- *     summary: Authenticate user and return a JWT token
+ *     summary: Authenticate user and return JWT and refresh tokens
  *     requestBody:
  *       required: true
  *       content:
@@ -30,6 +30,15 @@ const authController = require('../controllers/authController');
  *     responses:
  *       200:
  *         description: Authentication successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                 refreshToken:
+ *                   type: string
  *       401:
  *         description: Invalid credentials
  *       500:


### PR DESCRIPTION
## Summary
- add generation of refresh token on login
- document refresh token in login Swagger docs

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842007220f48333960fede7d5762460