### PR TITLE
Add refresh token endpoint

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -17,3 +17,26 @@ exports.login = async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 };
+
+exports.refreshToken = async (req, res) => {
+  const { refreshToken } = req.body;
+  if (!refreshToken) {
+    return res.status(400).json({ message: 'Refresh token required' });
+  }
+  try {
+    const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET);
+    const token = jwt.sign(
+      { id: decoded.id, role: decoded.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+    const newRefreshToken = jwt.sign(
+      { id: decoded.id, role: decoded.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+    res.json({ token, refreshToken: newRefreshToken });
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid refresh token' });
+  }
+};

--- a/routes/loginRoutes.js
+++ b/routes/loginRoutes.js
@@ -46,4 +46,39 @@ const authController = require('../controllers/authController');
  */
 router.post('/login', authController.login);
 
+/**
+ * @swagger
+ * /api/refresh:
+ *   post:
+ *     tags:
+ *       - Login
+ *     summary: Refresh JWT using a refresh token
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               refreshToken:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: New authentication tokens
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                 refreshToken:
+ *                   type: string
+ *       400:
+ *         description: Refresh token required
+ *       401:
+ *         description: Invalid refresh token
+ */
+router.post('/refresh', authController.refreshToken);
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- implement refreshToken controller
- create `/api/refresh` route with swagger docs

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684201c0917c833394dc612a83ea37ae